### PR TITLE
Fix French typo in messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ async def handle_album(client, message):
         price = price_match.group(1).strip() if price_match else "Non spécifié"
 
         final_caption = (
-            f"🔎 Prend ton : {article}\n"
+            f"🔎 Prends ton : {article}\n"
             f"💵Price : {price}\n"
             f"🖇 CnFans Link : {cnfans_link_with_ref}\n\n"
             f"🥇 Inscris-toi avec ce lien pour avoir des réductions sur CNFANS 🥇\n"
@@ -111,7 +111,7 @@ async def forward_single(client, message):
     price = price_match.group(1).strip() if price_match else "Non spécifié"
 
     new_text = (
-        f"🔎 Prend ton : {article}\n"
+        f"🔎 Prends ton : {article}\n"
         f"💵Price : {price}\n"
         f"🖇 CnFans Link : {cnfans_link_with_ref}\n\n"
         f"🥇 Inscris-toi avec ce lien pour avoir des réductions sur CNFANS 🥇\n"


### PR DESCRIPTION
## Summary
- correct "Prend ton" to "Prends ton" in album and single message captions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686505799c548330a69cd4d310edbea8